### PR TITLE
Create speed bonus/debuff for lower health sprites

### DIFF
--- a/objects/objPlayer.object.gmx
+++ b/objects/objPlayer.object.gmx
@@ -85,9 +85,9 @@ fixed_timestep_register_script(id, stateUpdate);
 grav               = 0.35;
 horizontalSpeed    = 0;
 verticalSpeed      = 0;
-maxHorizontalSpeed = 3;
+maxHorizontalSpeed = MAXHORIZONTALSPEED;
 maxVerticalSpeed   = 8;
-acceleration       = 0.4;
+acceleration       = 0.5;
 slideFactor        = 2;
 
 // for backdash
@@ -196,6 +196,31 @@ event_inherited();
         </arguments>
       </action>
     </event>
+    <event eventtype="2" enumb="1">
+      <action>
+        <libid>1</libid>
+        <id>603</id>
+        <kind>7</kind>
+        <userelative>0</userelative>
+        <isquestion>0</isquestion>
+        <useapplyto>-1</useapplyto>
+        <exetype>2</exetype>
+        <functionname></functionname>
+        <codestring></codestring>
+        <whoName>self</whoName>
+        <relative>0</relative>
+        <isnot>0</isnot>
+        <arguments>
+          <argument>
+            <kind>1</kind>
+            <string>maxHorizontalSpeed = MAXHORIZONTALSPEED;
+image_speed        = IMAGESPEED;
+
+</string>
+          </argument>
+        </arguments>
+      </action>
+    </event>
     <event eventtype="2" enumb="0">
       <action>
         <libid>1</libid>
@@ -288,6 +313,7 @@ if (playerStart) {
           <argument>
             <kind>1</kind>
             <string>///Check HP
+
 if (hp &lt;= 0) {
     game_end();
 }

--- a/poetryPlatformer.project.gmx
+++ b/poetryPlatformer.project.gmx
@@ -49,6 +49,16 @@
       <script>scripts\stateCollectibleDying.gml</script>
       <script>scripts\stateCollectibleDead.gml</script>
     </scripts>
+    <scripts name="eventScripts">
+      <script>scripts\collectibleFound.gml</script>
+      <script>scripts\platformLandedOn.gml</script>
+      <script>scripts\removePlatformHightlight.gml</script>
+    </scripts>
+    <scripts name="eventTriggering">
+      <script>scripts\eventRegister.gml</script>
+      <script>scripts\eventFire.gml</script>
+      <script>scripts\eventUnregister.gml</script>
+    </scripts>
     <scripts name="FSMScripts">
       <script>scripts\stateMachineInit.gml</script>
       <script>scripts\stateCreate.gml</script>
@@ -71,9 +81,6 @@
       <script>scripts\stateInCollectionAnimation.gml</script>
       <script>scripts\stateRespawn.gml</script>
     </scripts>
-    <scripts name="sharedFunctions">
-      <script>scripts\horizontalMovement.gml</script>
-    </scripts>
     <scripts name="timestepScripts">
       <script>scripts\_fixed_timestep_ev_create.gml</script>
       <script>scripts\_fixed_timestep_ev_destroy.gml</script>
@@ -86,21 +93,12 @@
       <script>scripts\fixed_timestep_update.gml</script>
     </scripts>
     <scripts name="util">
+      <script>scripts\horizontalMovement.gml</script>
       <script>scripts\hideController.gml</script>
       <script>scripts\spawnLetters.gml</script>
       <script>scripts\pushPlayerOut.gml</script>
       <script>scripts\heal.gml</script>
       <script>scripts\takeDamage.gml</script>
-    </scripts>
-    <scripts name="eventTriggering">
-      <script>scripts\eventRegister.gml</script>
-      <script>scripts\eventFire.gml</script>
-      <script>scripts\eventUnregister.gml</script>
-    </scripts>
-    <scripts name="eventScripts">
-      <script>scripts\collectibleFound.gml</script>
-      <script>scripts\platformLandedOn.gml</script>
-      <script>scripts\removePlatformHightlight.gml</script>
     </scripts>
   </scripts>
   <fonts name="fonts">
@@ -143,10 +141,11 @@
     <room>rooms\testRoom</room>
     <room>rooms\room4</room>
   </rooms>
-  <constants number="3">
+  <constants number="4">
     <constant name="customDeltaTime">global.timeFactor * ((60 / global._ts_fps) * (delta_time / ((1 / room_speed) * 1000000)))</constant>
     <constant name="COLLECTIBLES">5</constant>
     <constant name="IMAGESPEED">global.timeFactor * (1 / (room_speed * 0.1))</constant>
+    <constant name="MAXHORIZONTALSPEED">3.75</constant>
   </constants>
   <help>
     <rtf>help.rtf</rtf>

--- a/scripts/horizontalMovement.gml
+++ b/scripts/horizontalMovement.gml
@@ -7,9 +7,11 @@ if (leftHeld && rightHeld) {
 
 image_xscale = facingDir;
 
+var maxSpeed = maxHorizontalSpeed - (exp((maxHp - hp) / maxHp) - 1);
+
 // accelerate
-if (-maxHorizontalSpeed < horizontalSpeed < maxHorizontalSpeed) {
+if (-maxSpeed < horizontalSpeed < maxSpeed) {
     horizontalSpeed += (facingDir) * argument[0] * customDeltaTime;
-    horizontalSpeed = clamp(horizontalSpeed, -maxHorizontalSpeed, maxHorizontalSpeed);
+    horizontalSpeed = clamp(horizontalSpeed, -maxSpeed, maxSpeed);
 }
 

--- a/scripts/stateDrop.gml
+++ b/scripts/stateDrop.gml
@@ -76,6 +76,15 @@ if (horizontalSpeed != 0) {
 instance = instance_place(round(x), round(y) + 1, objBottoms);
 if (verticalSpeed == 0 && instance) {
     eventFire(allEvents.landedon, instance);
+    
+    if (hp <= 3) {
+        alarm[1] = room_speed * 0.5 * customDeltaTime;
+        image_speed = IMAGESPEED - 0.1;
+        maxHorizontalSpeed = MAXHORIZONTALSPEED - 0.66;
+        if (hp == 1) {
+            maxHorizontalSpeed = MAXHORIZONTALSPEED - 1;
+        }
+    }
 
     if (horizontalSpeed != 0 || (leftHeld || rightHeld)) {
         stateSwitch("walk");


### PR DESCRIPTION
Created MAXHORIZONTALSPEED macro
Added exponential scaling speed debuff according to player health, to match sprite changes
Added landing impact "frames" by reducing imageSpeed and horizontal speed for half a second
Adjusted acceleration value

Closes #26 