### PR TITLE
 Investigate horizontal speed reduction bugs

### DIFF
--- a/scripts/horizontalMovement.gml
+++ b/scripts/horizontalMovement.gml
@@ -7,7 +7,7 @@ if (leftHeld && rightHeld) {
 
 image_xscale = facingDir;
 
-var maxSpeed = maxHorizontalSpeed - (exp((maxHp - hp) / maxHp) - 1);
+var maxSpeed = maxHorizontalSpeed - (exp((maxHp - hp) / maxHp) - 1) * 0.5;
 
 // accelerate
 if (-maxSpeed < horizontalSpeed < maxSpeed) {


### PR DESCRIPTION
Changed speed reduction function to be from 0 to 0.5 rather than 0 to 1, at minimum speed it does not bug anymore. Also feels better while still keeping the nature of the feature

Closes #35 